### PR TITLE
Add support for tagging with golang pseudoversions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM --platform=$BUILDPLATFORM ${GO_IMAGE} as base-builder
 COPY --from=xx / /
 RUN set -x && \
     apk --no-cache add \
+    gawk \
     jq \
     file \
     gcc \


### PR DESCRIPTION
This repo currently builds against the the +k3s1 tag that corresponds to the build tag. This PR adds support for tagging with golang pseudo-version strings, to build against commits of the K3s repo that have not yet been tagged.

Example: `make TAG=v1.31.2-0.20241011135109-46cfd2cf55d3-build20241014` to build against the (current) head of the release-1.31 branch: https://github.com/k3s-io/k3s/commit/46cfd2cf55d3