### PR TITLE
Ignore go module proxy for github.com/k3s-io/k3s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ARG PKG="github.com/rancher/image-build-rke2-cloud-provider"
 COPY . /$GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN go install github.com/davidrjonas/semver-cli@1.1.1
+ENV GONOSUMDB=github.com/k3s-io/k3s GONOPROXY=github.com/k3s-io/k3s
 RUN ./scripts/modsync.sh ${TAG}
 RUN go mod download
 # cross-compilation setup


### PR DESCRIPTION
Fixes issues with `sum.golang.org` caching failed commit lookups:
```
#26 288.8 go: github.com/k3s-io/k3s@v1.31.2-0.20241012053821-d74ad4253a54: verifying go.mod: github.com/k3s-io/k3s@v1.31.2-0.20241012053821-d74ad4253a54/go.mod: reading https://sum.golang.org/lookup/github.com/k3s-io/k3s@v1.31.2-0.20241012053821-d74ad4253a54: 404 Not Found
#26 288.8 	server response: not found
```

yet this commit pseudoversion clearly exists in the repo: https://github.com/k3s-io/k3s/commit/d74ad4253a54
